### PR TITLE
Restructure contact data to use unique ids for keys

### DIFF
--- a/contacts.yml
+++ b/contacts.yml
@@ -1,16 +1,31 @@
 ---
-andrea:
+0:
+  name: Andrea Bocelli
   phone: '987654321'
   email: andrea@andrea.com
   address: 456 Bet Drive
-  category: family,
-luca:
+  category:
+1:
+  name: Luca
   phone: '123123123'
   email: luca@luca.com
   address: 789 Gamma Drive
   category: friend
-ilke:
+2:
+  name: Ilke
   phone: '787878787878'
   email: ilke@ilke.com
   address: 123 Hyphen Road
   cateogory: family
+3:
+  name: Seamus Healey
+  phone: '123466'
+  email: seamus@oreilly.lck
+  address: 123 Sesame Street
+  category:
+4:
+  name: Silly Jean
+  phone: '010101010'
+  email: tee@hee.mj
+  address: Neverland Woo
+  category:

--- a/views/contact.erb
+++ b/views/contact.erb
@@ -1,11 +1,11 @@
 <div class="container">
 	<div id="subheader">
-		<h1><%= @contact_name %></h1>
+		<h1><%= @details["name"] %></h1>
 		<div>
 			<a href="/" class="btn btn-link btn-md">
 				Back
 			</a>
-			<a href="/contacts/<%= @contact_name %>/edit" class="btn btn-primary btn-md">
+			<a href="/contacts/<%= params[:id] %>/edit" class="btn btn-primary btn-md">
 				Edit
 			</a>
 		</div>

--- a/views/contact_list.rb
+++ b/views/contact_list.rb
@@ -19,16 +19,17 @@ get "/" do
   redirect "/contacts"
 end
 
-helpers do
-  def generate_id # generates unique user id
-    contacts = YAML.load_file("contacts.yml")
-    contacts.keys.max + 1
-  end
-end
+# helpers do
+#   def generate_id # generates unique user id
+#     contacts = YAML.load_file("contacts.yml")
+#     contacts.select {|contact| contact["name"] }.max
+#   end
+# end
 
 get "/contacts" do
-  @contacts = YAML.load_file("contacts.yml")
-
+  contacts = YAML.load_file("contacts.yml")
+  puts contacts
+  @contact_names = contacts.values["name"]
   erb :contacts, layout: :layout
 end
 
@@ -38,15 +39,16 @@ get "/contacts/new" do
 end
 
 # view a single contact
-get "/contacts/:id" do
-  contacts = YAML.load_file("contacts.yml")
-  @details = contacts.fetch(params[:id].to_i)
+get "/contacts/:name" do
+  @contacts = YAML.load_file("contacts.yml")
+  @contact_name = params[:name]
+  @details = @contacts[@contact_name]
 
   erb :contact, layout: :layout
 end
 
 # create a new contact
-post "/contacts/new" do
+post "/contacts" do
   contact_name = params[:contact_name]
   phone = params[:phone]
   email = params[:email]
@@ -54,23 +56,23 @@ post "/contacts/new" do
   category = params[:category]
 
   contacts = YAML.load_file("contacts.yml")
-  contacts[generate_id] = {"name" => contact_name, "phone" => phone, "email" => email, "address" => address, "category" => category}
+  contacts[contact_name] = {"phone" => phone, "email" => email, "address" => address, "category" => category}
   File.open("contacts.yml", 'w') { |f| YAML.dump(contacts, f) }
 
   redirect "/contacts"
 end
 
 # render the edit contact page
-get "/contacts/:id/edit" do
-  contacts = YAML.load_file("contacts.yml")
-  @details = contacts.fetch(params[:id].to_i)
-  @id = params[:id]
+get "/contacts/:name/edit" do
+  @contacts = YAML.load_file("contacts.yml")
+  @contact_name = params[:name]
+  @details = @contacts[@contact_name]
 
   erb :edit, layout: :layout
 end
 
 # edit a contact
-post "/contacts/:id/edit" do
+post "/contacts/:name/edit" do
   contact_name = params[:contact_name]
   phone = params[:phone]
   email = params[:email]
@@ -78,20 +80,18 @@ post "/contacts/:id/edit" do
   category = params[:category]
 
   contacts = YAML.load_file("contacts.yml")
-  contacts[params[:id].to_i] = {"name" => contact_name, "phone" => phone, "email" => email, "address" => address, "category" => category}
+  contacts[contact_name] = {"name" => contact_name, "phone" => phone, "email" => email, "address" => address, "category" => category}
   File.open("contacts.yml", 'w') { |f| YAML.dump(contacts, f) }
 
-  redirect "/contacts/#{params[:id]}"
+  redirect "/contacts"
 end
 
 # delete a contact
-post "/contacts/:id/delete" do
+post "/contacts/:name/delete" do
   contacts = YAML.load_file("contacts.yml")
-  contact_id = params[:id]
+  contact_name = params[:name]
 
-  contacts.delete(contact_id.to_i)
-  puts contact_id
-  puts contacts
+  contacts.delete(contact_name)
   File.open("contacts.yml", 'w') { |f| YAML.dump(contacts, f) }
 
   redirect "/contacts"

--- a/views/contacts.erb
+++ b/views/contacts.erb
@@ -7,13 +7,15 @@
 	</div>
 
 	<ul class="list-name">
-		<% @contact_names.each do |contact_name| %>
+		<% @contacts.each do |key, value| %>
 			<li class="list-name-item">
-				<a href="/contacts/<%= contact_name %>"><%= contact_name %></a>
+				<a href="/contacts/<%= key %>"><%= value["name"] %></a>
 				<div>
-					<button type="button" class="btn btn-link btn-sm">
-						<i class="fa-solid fa-trash"></i>
-					</button>
+					<form action="/contacts/<%= key %>/delete" method="post">
+						<button type="submit" class="btn btn-link btn-sm">
+							<i class="fa-solid fa-trash"></i>
+						</button>
+					</form>
 				</div>
 			</li>
 		<% end %>

--- a/views/edit.erb
+++ b/views/edit.erb
@@ -1,13 +1,13 @@
 <div class="container">
 	<div id="subheader">
-		<h1><%= @contact_name %></h1>
+		<h1><%= @details["name"] %></h1>
 	</div>
 
 	<div id="contact-details">
-		<form>
+		<form action="/contacts/<%= @id %>/edit" method="post">
 	  		<div class="form-group">
 	  			<label for="name">Name</label>
-	  			<input class="form-control" type="text" id="name" name="name" value="<%= @contact_name %>"></input>
+	  			<input class="form-control" type="text" id="contact_name" name="contact_name" value="<%= @details["name"] %>"></input>
 	  		</div>
 	  		<div class="form-group">
 	  			<label for="phone">Phone</label>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -15,6 +15,11 @@
       </div>
   	</header>
     <main>
+      <% if session[:message] %>
+        <div class="message">
+          <p><%= session.delete(:message) %></p>
+        </div>
+      <% end %>
     	<%= yield %>
     </main>
   </body>

--- a/views/new.erb
+++ b/views/new.erb
@@ -4,7 +4,11 @@
 	</div>
 
 	<div id="contact-details">
-		<form>
+		<form action="/contacts/new" method="post">
+			<div class="form-group">
+	  			<label for="contact-name">Name</label>
+	  			<input class="form-control" type="text" id="contact_name" name="contact_name"></input>
+	  		</div>
 	  		<div class="form-group">
 	  			<label for="phone">Phone</label>
 	  			<input class="form-control" type="tel" id="phone" name="phone" value=""></input>


### PR DESCRIPTION
Two issues with the existing contact data structure where keys double as names:
1. When changing the name of an existing contact, instead of updating the contact, a new contact is created.
2. When creating a new contact where the name already exists, the existing contact is overridden.

This updates the data structure of contacts, and its attendant logic to reference unique `contact_id`'s which resolves the above issues.